### PR TITLE
 Allow quoted triples to be expressed, Closes #18 

### DIFF
--- a/spec/data.n3
+++ b/spec/data.n3
@@ -1,0 +1,16 @@
+@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:	    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:         <http://ns.example.org/#> .
+
+_:a  foaf:name       "Alice" .
+_:a  foaf:homepage   <http://work.example.org/alice/> .
+_:a  foaf:mbox       "" .
+_:a  ex:blurb       "<p xmlns=\"http://www.w3.org/1999/xhtml\">My name is <em>Alice</em></p>"^^rdf:XMLLiteral .
+_:a  foaf:knows      _:b .
+
+_:b  foaf:name       "Bob"@en .
+_:b  foaf:mbox       <mailto:bob@work.example.org> .
+_:b  foaf:homepage   <http://work.example.org/bob/> .
+_:b  ex:ageInYears   30 .
+_:b  foaf:knows      _:a .

--- a/spec/data.n3
+++ b/spec/data.n3
@@ -8,9 +8,11 @@ _:a  foaf:homepage   <http://work.example.org/alice/> .
 _:a  foaf:mbox       "" .
 _:a  ex:blurb       "<p xmlns=\"http://www.w3.org/1999/xhtml\">My name is <em>Alice</em></p>"^^rdf:XMLLiteral .
 _:a  foaf:knows      _:b .
+_:a  ex:quoted       <<http://example.org/alice> <http://example.org/name> "Alice"> .
 
 _:b  foaf:name       "Bob"@en .
 _:b  foaf:mbox       <mailto:bob@work.example.org> .
 _:b  foaf:homepage   <http://work.example.org/bob/> .
 _:b  ex:ageInYears   30 .
 _:b  foaf:knows      _:a .
+_:b  ex:quoted       <<http://example.org/bob> <http://example.org/name> "Bob"> .

--- a/spec/example-quoted.rq
+++ b/spec/example-quoted.rq
@@ -1,0 +1,9 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ex: <http://ns.example.org/#>
+
+SELECT ?x ?name ?quoted
+FROM <data.n3>
+WHERE { ?x foaf:name ?name .
+        ?x ex:quoted ?quoted .
+      }
+ORDER BY ?name

--- a/spec/example.rq
+++ b/spec/example.rq
@@ -1,0 +1,13 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ex: <http://ns.example.org/#>
+
+SELECT ?x ?hpage ?name ?mbox ?age ?blurb ?friend
+FROM <data.n3>
+WHERE { ?x foaf:name ?name .
+        ?x foaf:mbox ?mbox .
+        ?x foaf:homepage ?hpage .
+        ?x foaf:knows ?friend .
+        OPTIONAL { ?x ex:ageInYears ?age } .
+        OPTIONAL { ?x ex:blurb ?blurb }
+      }
+ORDER BY ?name

--- a/spec/example.rq
+++ b/spec/example.rq
@@ -1,12 +1,13 @@
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ex: <http://ns.example.org/#>
 
-SELECT ?x ?hpage ?name ?mbox ?age ?blurb ?friend
+SELECT ?x ?hpage ?name ?mbox ?age ?blurb ?friend ?quoted
 FROM <data.n3>
 WHERE { ?x foaf:name ?name .
         ?x foaf:mbox ?mbox .
         ?x foaf:homepage ?hpage .
         ?x foaf:knows ?friend .
+        ?x ex:quoted ?quoted .
         OPTIONAL { ?x ex:ageInYears ?age } .
         OPTIONAL { ?x ex:blurb ?blurb }
       }

--- a/spec/example.rq
+++ b/spec/example.rq
@@ -1,13 +1,12 @@
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ex: <http://ns.example.org/#>
 
-SELECT ?x ?hpage ?name ?mbox ?age ?blurb ?friend ?quoted
+SELECT ?x ?hpage ?name ?mbox ?age ?blurb ?friend
 FROM <data.n3>
 WHERE { ?x foaf:name ?name .
         ?x foaf:mbox ?mbox .
         ?x foaf:homepage ?hpage .
         ?x foaf:knows ?friend .
-        ?x ex:quoted ?quoted .
         OPTIONAL { ?x ex:ageInYears ?age } .
         OPTIONAL { ?x ex:blurb ?blurb }
       }

--- a/spec/example2.rq
+++ b/spec/example2.rq
@@ -1,0 +1,5 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+ASK
+  FROM <data.n3>
+  WHERE { ?x foaf:name ?name }

--- a/spec/index.html
+++ b/spec/index.html
@@ -499,8 +499,17 @@ span.cancast:hover { background-color: #ffa;
     <dd><code>&lt;binding&gt;&lt;literal datatype="</code><em>D</em><code>"&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
     <dt>Blank Node label <em>I</em><br></dt>
     <dd><code>&lt;binding&gt;&lt;bnode&gt;</code><em>I</em><code>&lt;/bnode&gt;&lt;/binding&gt;</code></dd>
+    <dt>Quoted Triple, with subject <em>S</em>, predicate <em>P</em>, object <em>O</em><br></dt>
+    <dd><code>&lt;binding&gt;<br />
+&nbsp;&nbsp;&lt;triple&gt;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt;</code><em>S</em><code>&lt;/subject&gt;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;predicate&gt;</code><em>P</em><code>&lt;/predicate&gt;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;object&gt;</code><em>O</em><code>&lt;/object&gt;<br />
+&nbsp;&nbsp;&lt;/triple&gt;<br />
+&lt;/binding&gt;</code></dd>
   </dl>
   <p>If, for a particular solution, a variable is <em>unbound</em>, no <code>binding</code> element for that variable is included in the <code>result</code> element.</p>
+  <p><em>S</em>, <em>P</em>, and <em>O</em> in Quoted Triples are encoded recursively, using the same format, without the enclosing <code>&lt;binding&gt;</code> tag</p>
   <p><strong>Note:</strong> The blank node label <em>I</em> is scoped to the result set XML document and need not have any association to the blank node label for that RDF Term in the query
   graph.</p>
   <p>An example of a query solution encoded in this format is as follows:</p>
@@ -514,6 +523,7 @@ span.cancast:hover { background-color: #ffa;
     &lt;variable name="age"/&gt;
     &lt;variable name="mbox"/&gt;
     &lt;variable name="friend"/&gt;
+    &lt;variable name="quoted"/&gt;
   &lt;/head&gt;
 
   &lt;results&gt;
@@ -533,6 +543,19 @@ span.cancast:hover { background-color: #ffa;
       &lt;/binding&gt;
       &lt;binding name="mbox"&gt;
         &lt;uri&gt;mailto:bob@work.example.org&lt;/uri&gt;
+      &lt;/binding&gt;
+      &lt;binding name="quoted"&gt;
+        &lt;triple&gt;
+            &lt;subject&gt;
+                &lt;uri&gt;http://example.org/alice&lt;/uri&gt;
+            &lt;/subject&gt;
+            &lt;predicate&gt;
+                &lt;uri&gt;http://example.org/name&lt;/uri&gt;
+            &lt;/predicate&gt;
+            &lt;object&gt;
+                &lt;literal datatype="http://www.w3.org/2001/XMLSchema#string"&gt;Alice&lt;/literal&gt;
+            &lt;/object&gt;
+        &lt;/triple&gt;
       &lt;/binding&gt;
     &lt;/result&gt;
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -523,7 +523,6 @@ span.cancast:hover { background-color: #ffa;
     &lt;variable name="age"/&gt;
     &lt;variable name="mbox"/&gt;
     &lt;variable name="friend"/&gt;
-    &lt;variable name="quoted"/&gt;
   &lt;/head&gt;
 
   &lt;results&gt;
@@ -543,6 +542,31 @@ span.cancast:hover { background-color: #ffa;
       &lt;/binding&gt;
       &lt;binding name="mbox"&gt;
         &lt;uri&gt;mailto:bob@work.example.org&lt;/uri&gt;
+      &lt;/binding&gt;
+
+    ...
+  &lt;/results&gt;
+
+&lt;/sparql&gt;
+</pre>
+  <p>An example of a query solution that includes quoted triples is as follows:</p>
+  <pre>&lt;?xml version="1.0"?&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+
+  &lt;head&gt;
+    &lt;variable name="x"/&gt;
+    &lt;variable name="name"/&gt;
+    &lt;variable name="quoted"/&gt;
+  &lt;/head&gt;
+
+  &lt;results&gt;
+
+    &lt;result&gt; 
+      &lt;binding name="x"&gt;
+        &lt;bnode&gt;r2&lt;/bnode&gt;
+      &lt;/binding&gt;
+      &lt;binding name="name"&gt;
+        &lt;literal xml:lang="en"&gt;Bob&lt;/literal&gt;
       &lt;/binding&gt;
       &lt;binding name="quoted"&gt;
         &lt;triple&gt;
@@ -593,6 +617,13 @@ span.cancast:hover { background-color: #ffa;
   <p>This XML can be transformed into XHTML using the sample XML Query script <a href="http://www.w3.org/2009/sparql/xml-results/result-to-html.xq">result-to-html.xq</a> giving <a href=
   "http://www.w3.org/2009/sparql/xml-results/output-xquery.html">output-xquery.html</a> or with XSLT sheet <a href=
   "http://www.w3.org/2009/sparql/xml-results/result-to-html.xsl">result-to-html.xsl</a> giving <a href="http://www.w3.org/2009/sparql/xml-results/output-xslt.html">output-xslt.html</a></p>
+      </section>
+
+      <section id="vb-quoted-examples">
+  <h3>Variable Binding Results Examples with Quoted Triples</h3>
+  <p>An example <code>SELECT</code> SPARQL Query in <a href="http://www.w3.org/2009/sparql/xml-results/example-quoted.rq">example-quoted.rq</a> operating on query graph Turtle/N3 data in <a href=
+  "http://www.w3.org/2009/sparql/xml-results/data.n3">data.n3</a> providing ordered variable binding query results written in XML in <a href=
+  "http://www.w3.org/2009/sparql/xml-results/output-quoted.srx">output-quoted.srx</a>. These results contain quoted triples.</p>
       </section>
 
       <section id="boolean-examples">

--- a/spec/output-quoted.srx
+++ b/spec/output-quoted.srx
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+
+  <head>
+    <variable name="x"/>
+    <variable name="name"/>
+    <variable name="quoted"/>
+
+    <link href="example-quoted.rq" />
+  </head>
+
+  <results>
+
+    <result>
+      <binding name="x"><bnode>r1</bnode></binding>
+      <binding name="name"><literal>Alice</literal></binding>
+      <binding name="quoted">
+        <triple>
+          <subject>
+              <uri>http://example.org/alice</uri>
+          </subject>
+          <predicate>
+              <uri>http://example.org/name</uri>
+          </predicate>
+          <object>
+              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Alice</literal>
+          </object>
+        </triple>
+      </binding>
+    </result>
+
+    <result> 
+      <binding name="x"><bnode>r2</bnode></binding>
+      <binding name="name"><literal xml:lang="en">Bob</literal></binding>
+      <binding name="quoted">
+        <triple>
+          <subject>
+              <uri>http://example.org/bob</uri>
+          </subject>
+          <predicate>
+              <uri>http://example.org/name</uri>
+          </predicate>
+          <object>
+              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Bob</literal>
+          </object>
+        </triple>
+      </binding>
+    </result>
+
+  </results>
+
+</sparql>

--- a/spec/output-xquery.html
+++ b/spec/output-xquery.html
@@ -1,0 +1,48 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+      <title>SPARQL Query Results to XHTML (XQuery)</title>
+   </head>
+   <body>
+      <h1>SPARQL Query Results to XHTML (XQuery)</h1>
+      <div>
+         <h2>Header</h2>
+         <p>Link to example.rq</p>
+      </div>
+      <div>
+         <h2>Variable Bindings Results</h2>
+         <table border="1">
+            <tbody><tr>
+               <th>x</th>
+               <th>hpage</th>
+               <th>name</th>
+               <th>mbox</th>
+               <th>age</th>
+               <th>blurb</th>
+               <th>friend</th>
+            </tr>
+            <tr>
+               <td>nodeID r1</td>
+               <td>URI http://work.example.org/alice/</td>
+               <td>Alice</td>
+               <td>[empty literal]</td>
+               <td>[unbound]</td>
+               <td>&lt;p xmlns="http://www.w3.org/1999/xhtml"&gt;My name
+ is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt; (datatype 
+http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral)</td>
+               <td>nodeID r2</td>
+            </tr>
+            <tr>
+               <td>nodeID r2</td>
+               <td>URI http://work.example.org/bob/</td>
+               <td>Bob@en</td>
+               <td>URI mailto:bob@work.example.org</td>
+               <td>30 (datatype http://www.w3.org/2001/XMLSchema#integer)</td>
+               <td>[unbound]</td>
+               <td>nodeID r1</td>
+            </tr>
+         </tbody></table>
+      </div>
+   
+
+</body></html>

--- a/spec/output-xquery2.html
+++ b/spec/output-xquery2.html
@@ -1,0 +1,17 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+      <title>SPARQL Query Results to XHTML (XQuery)</title>
+   </head>
+   <body>
+      <h1>SPARQL Query Results to XHTML (XQuery)</h1>
+      <div>
+         <h2>Header</h2>
+         <p>Link to example2.rq</p>
+      </div>
+      <div>
+         <h2>Boolean Result</h2>
+         <p>Value: true</p>
+      </div>
+   
+</body></html>

--- a/spec/output-xslt.html
+++ b/spec/output-xslt.html
@@ -1,0 +1,60 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+      <title>SPARQL Query Results to XHTML (XSLT)</title>
+   </head>
+   <body>
+      <h1>SPARQL Query Results to XHTML (XSLT)</h1>
+      <div>
+         <h2>Header</h2>
+         <p>Link to example.rq</p>
+      </div>
+      <div>
+         <h2>Variable Bindings Result</h2>
+         <table border="1">
+	           <tbody><tr>
+               <th>x</th>
+               <th>hpage</th>
+               <th>name</th>
+               <th>mbox</th>
+               <th>age</th>
+               <th>blurb</th>
+               <th>friend</th>
+            </tr>
+	           <tr>
+               <td>nodeID r1</td>
+               <td>URI http://work.example.org/alice/</td>
+               <td>Alice</td>
+               <td>
+	
+	[empty literal]
+      </td>
+               <td>
+	    
+	    [unbound]
+	  </td>
+               <td>&lt;p xmlns="http://www.w3.org/1999/xhtml"&gt;My name
+ is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt; (datatype 
+http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral )
+      </td>
+               <td>nodeID r2</td>
+            </tr>
+            <tr>
+               <td>nodeID r2</td>
+               <td>URI http://work.example.org/bob/</td>
+               <td>Bob @ en</td>
+               <td>URI mailto:bob@work.example.org</td>
+               <td>30 (datatype http://www.w3.org/2001/XMLSchema#integer )
+      </td>
+               <td>
+	    
+	    [unbound]
+	  </td>
+               <td>nodeID r1</td>
+            </tr>
+         </tbody></table>
+      </div>
+   
+
+</body></html>

--- a/spec/output-xslt2.html
+++ b/spec/output-xslt2.html
@@ -1,0 +1,18 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+      <title>SPARQL Query Results to XHTML (XSLT)</title>
+   </head>
+   <body>
+      <h1>SPARQL Query Results to XHTML (XSLT)</h1>
+      <div>
+         <h2>Header</h2>
+         <p>Link to example2.rq</p>
+      </div>
+      <div>
+         <h2>Boolean Result</h2>
+         <p>Value true</p>
+      </div>
+   
+</body></html>

--- a/spec/output.srx
+++ b/spec/output.srx
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+
+  <head>
+    <variable name="x"/>
+    <variable name="hpage"/>
+    <variable name="name"/>
+    <variable name="mbox"/>
+    <variable name="age"/>
+    <variable name="blurb"/>
+    <variable name="friend"/>
+
+    <link href="example.rq" />
+  </head>
+
+  <results>
+
+    <result>
+      <binding name="x"><bnode>r1</bnode></binding>
+      <binding name="hpage"><uri>http://work.example.org/alice/</uri></binding>
+      <binding name="name"><literal>Alice</literal></binding>
+      <binding name="mbox"><literal></literal></binding>
+      <binding name="friend"><bnode>r2</bnode></binding>
+      <binding name="blurb"><literal datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">&lt;p xmlns="http://www.w3.org/1999/xhtml"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;</literal></binding>
+    </result>
+
+    <result> 
+      <binding name="x"><bnode>r2</bnode></binding>
+      <binding name="hpage"><uri>http://work.example.org/bob/</uri></binding>
+      <binding name="name"><literal xml:lang="en">Bob</literal></binding>
+      <binding name="mbox"><uri>mailto:bob@work.example.org</uri></binding>
+      <binding name="age"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">30</literal></binding>
+      <binding name="friend"><bnode>r1</bnode></binding>
+    </result>
+
+  </results>
+
+</sparql>

--- a/spec/output.srx
+++ b/spec/output.srx
@@ -11,7 +11,6 @@
     <variable name="age"/>
     <variable name="blurb"/>
     <variable name="friend"/>
-    <variable name="quoted"/>
 
     <link href="example.rq" />
   </head>
@@ -25,19 +24,6 @@
       <binding name="mbox"><literal></literal></binding>
       <binding name="friend"><bnode>r2</bnode></binding>
       <binding name="blurb"><literal datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">&lt;p xmlns="http://www.w3.org/1999/xhtml"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;</literal></binding>
-      <binding name="quoted">
-        <triple>
-          <subject>
-              <uri>http://example.org/alice</uri>
-          </subject>
-          <predicate>
-              <uri>http://example.org/name</uri>
-          </predicate>
-          <object>
-              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Alice</literal>
-          </object>
-        </triple>
-      </binding>
     </result>
 
     <result> 
@@ -47,19 +33,6 @@
       <binding name="mbox"><uri>mailto:bob@work.example.org</uri></binding>
       <binding name="age"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">30</literal></binding>
       <binding name="friend"><bnode>r1</bnode></binding>
-      <binding name="quoted">
-        <triple>
-          <subject>
-              <uri>http://example.org/bob</uri>
-          </subject>
-          <predicate>
-              <uri>http://example.org/name</uri>
-          </predicate>
-          <object>
-              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Bob</literal>
-          </object>
-        </triple>
-      </binding>
     </result>
 
   </results>

--- a/spec/output.srx
+++ b/spec/output.srx
@@ -11,6 +11,7 @@
     <variable name="age"/>
     <variable name="blurb"/>
     <variable name="friend"/>
+    <variable name="quoted"/>
 
     <link href="example.rq" />
   </head>
@@ -24,6 +25,19 @@
       <binding name="mbox"><literal></literal></binding>
       <binding name="friend"><bnode>r2</bnode></binding>
       <binding name="blurb"><literal datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">&lt;p xmlns="http://www.w3.org/1999/xhtml"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;</literal></binding>
+      <binding name="quoted">
+        <triple>
+          <subject>
+              <uri>http://example.org/alice</uri>
+          </subject>
+          <predicate>
+              <uri>http://example.org/name</uri>
+          </predicate>
+          <object>
+              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Alice</literal>
+          </object>
+        </triple>
+      </binding>
     </result>
 
     <result> 
@@ -33,6 +47,19 @@
       <binding name="mbox"><uri>mailto:bob@work.example.org</uri></binding>
       <binding name="age"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">30</literal></binding>
       <binding name="friend"><bnode>r1</bnode></binding>
+      <binding name="quoted">
+        <triple>
+          <subject>
+              <uri>http://example.org/bob</uri>
+          </subject>
+          <predicate>
+              <uri>http://example.org/name</uri>
+          </predicate>
+          <object>
+              <literal datatype="http://www.w3.org/2001/XMLSchema#string">Bob</literal>
+          </object>
+        </triple>
+      </binding>
     </result>
 
   </results>

--- a/spec/output2.srx
+++ b/spec/output2.srx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+
+  <head>
+    <link href="example2.rq" />
+  </head>
+
+  <boolean>true</boolean>
+
+</sparql>

--- a/spec/result-to-html.xq
+++ b/spec/result-to-html.xq
@@ -1,0 +1,132 @@
+xquery version "1.0";
+(:
+
+  XQuery script to format SPARQL Query Results XML Format into xhtml
+
+  Copyright © 2004, 2005 World Wide Web Consortium, (Massachusetts
+  Institute of Technology, European Research Consortium for
+  Informatics and Mathematics, Keio University). All Rights
+  Reserved. This work is distributed under the W3C® Software
+  License [1] in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+  $Id: result-to-html.xq,v 1.1 2012/11/07 00:38:29 sandro Exp $
+
+:)
+
+
+declare namespace res="http://www.w3.org/2005/sparql-results#";
+declare default element namespace "http://www.w3.org/1999/xhtml";
+
+
+(: URI of input SPARQL Query Results document :)
+declare variable $results-doc := doc( "output.srx" );
+
+
+(: How to set serialization parameters? :)
+
+(: doctype-system = "-//W3C//DTD XHTML 1.0 Transitional//EN" :)
+(: doctype-public = "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> :)
+
+
+declare variable $variableNames :=
+   for $element in $results-doc/res:sparql/res:head/res:variable
+     return string( $element/@name )
+;
+
+
+declare function local:head($head as node()) {
+  <div> 
+    <h2>Header</h2> 
+  {
+    for $link in $head/res:link
+      return <p>Link to { string( $link/@href ) }</p>
+  } </div>
+};
+
+
+declare function local:boolean-result($bool as node()) {
+  <div>
+    <h2>Boolean Result</h2>
+    <p>Value: { string ($bool) } </p>
+  </div>
+};
+
+
+declare function local:vb-result($vbr as node()) {
+  <div>
+    <h2>Variable Bindings Results</h2>
+
+    <table border="1">
+<tr> {
+  for $name in $variableNames
+    return <th>{$name}</th>
+} </tr>
+
+
+{ for $result in $vbr/res:result
+    return
+<tr> {
+  for $name in $variableNames 
+    let $item := $result/res:binding[@name = $name]
+    return  
+	<td> {
+	  if ($item/res:bnode) then
+	     (: blank node value :)
+	     ( "nodeID ", $item/res:bnode/text() )
+	  else if ($item/res:uri) then 
+	     (: URI value :)
+	     ( "URI ", $item/res:uri/text() )
+	  else if ($item/res:literal/@datatype) then 
+	     (: datatyped literal value :)
+	     fn:concat ( $item/res:literal, " (datatype ", $item/res:literal/@datatype, ")" )
+	  else if ($item/res:literal/@xml:lang) then 
+	     (: lang-string :)
+	     fn:concat ( $item/res:literal, "@", $item/res:literal/@xml:lang )
+	  else if ($item/res:literal/res:unbound) then 
+	     (: unbound variable - empty cell :)
+	     "[unbound]"
+	  else if ( exists($item/res:literal/text()) ) then
+	     (: present and not empty :)
+	     $item/res:literal/text()
+	  else if ( exists($item/res:literal) ) then
+	     (: present and empty :)
+	     "[empty literal]"
+	  else
+	     (: unbound variable - empty cell :)
+	     "[unbound]"
+	 } </td>
+  } </tr>
+
+} </table>
+
+</div>
+};
+
+
+document {
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>SPARQL Query Results to XHTML (XQuery)</title>
+  </head>
+  <body>
+    <h1>SPARQL Query Results to XHTML (XQuery)</h1>
+
+{
+  local:head($results-doc/res:sparql/res:head)
+}
+
+{
+if ($results-doc/res:sparql/res:boolean) then 
+  local:boolean-result($results-doc/res:sparql/res:boolean)
+else
+  local:vb-result($results-doc/res:sparql/res:results)
+}
+
+  </body>
+</html>
+
+}    

--- a/spec/result-to-html.xsl
+++ b/spec/result-to-html.xsl
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!--
+
+XSLT script to format SPARQL Query Results XML Format into xhtml
+
+Copyright © 2004, 2005 World Wide Web Consortium, (Massachusetts
+Institute of Technology, European Research Consortium for
+Informatics and Mathematics, Keio University). All Rights
+Reserved. This work is distributed under the W3C® Software
+License [1] in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+[1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+$Id: result-to-html.xsl,v 1.1 2012/11/07 00:38:29 sandro Exp $
+
+-->
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:res="http://www.w3.org/2005/sparql-results#"
+  exclude-result-prefixes="res xsl">
+
+  <!--
+  <xsl:output
+    method="html"
+    media-type="text/html"
+    doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN"
+    indent="yes"
+    encoding="UTF-8"/>
+  -->
+
+  <!-- or this? -->
+
+  <xsl:output
+    method="xml" 
+    indent="yes"
+    encoding="UTF-8" 
+    doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
+    doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+    omit-xml-declaration="no" />
+
+
+  <xsl:template name="header">
+    <div>
+      <h2>Header</h2>
+      <xsl:for-each select="res:head/res:link"> 
+	<p>Link to <xsl:value-of select="@href"/></p>
+      </xsl:for-each>
+    </div>
+  </xsl:template>
+
+  <xsl:template name="boolean-result">
+    <div>
+      <h2>Boolean Result</h2>
+      <p>Value <xsl:value-of select="res:boolean"/></p>
+    </div>
+  </xsl:template>
+
+
+  <xsl:template name="vb-result">
+    <div>
+      <h2>Variable Bindings Result</h2>
+
+      <table border="1">
+	<xsl:text>
+	</xsl:text>
+	<tr>
+	  <xsl:for-each select="res:head/res:variable">
+	    <th><xsl:value-of select="@name"/></th>
+	  </xsl:for-each>
+	</tr>
+	<xsl:text>
+	</xsl:text>
+	<xsl:for-each select="res:results/res:result">
+	  <tr>
+	    <xsl:apply-templates select="."/>
+	  </tr>
+	</xsl:for-each>
+      </table>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="res:result">
+    <xsl:variable name="current" select="."/>
+    <xsl:for-each select="//res:head/res:variable">
+      <xsl:variable name="name" select="@name"/>
+      <td>
+	<xsl:choose>
+	  <xsl:when test="$current/res:binding[@name=$name]">
+	    <!-- apply template for the correct value type (bnode, uri,
+	    literal) -->
+	    <xsl:apply-templates select="$current/res:binding[@name=$name]"/>
+	  </xsl:when>
+	  <xsl:otherwise>
+	    <!-- no binding available for this variable in this solution -->
+	    [unbound]
+	  </xsl:otherwise>
+	</xsl:choose>
+      </td>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="res:bnode">
+    <xsl:text>nodeID </xsl:text>
+    <xsl:value-of select="text()"/>
+  </xsl:template>
+
+  <xsl:template match="res:uri">
+    <xsl:variable name="uri" select="text()"/>
+    <xsl:text>URI </xsl:text>
+    <xsl:value-of select="$uri"/>
+  </xsl:template>
+
+  <xsl:template match="res:literal">
+    <xsl:choose>
+      <xsl:when test="@datatype">
+	<!-- datatyped literal value -->
+	<xsl:value-of select="text()"/> (datatype <xsl:value-of select="@datatype"/> )
+      </xsl:when>
+      <xsl:when test="@xml:lang">
+	<!-- lang-string -->
+	<xsl:value-of select="text()"/> @ <xsl:value-of select="@xml:lang"/>
+      </xsl:when>
+      <xsl:when test="string-length(text()) != 0">
+	<!-- present and not empty -->
+	<xsl:value-of select="text()"/>
+      </xsl:when>
+      <xsl:when test="string-length(text()) = 0">
+	<!-- present and empty -->
+	[empty literal]
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="res:sparql">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      <head>
+	<title>SPARQL Query Results to XHTML (XSLT)</title>
+      </head>
+      <body>
+
+
+	<h1>SPARQL Query Results to XHTML (XSLT)</h1>
+
+	<xsl:if test="res:head/res:link">
+	  <xsl:call-template name="header"/>
+	</xsl:if>
+
+	<xsl:choose>
+	  <xsl:when test="res:boolean">
+	    <xsl:call-template name="boolean-result" />
+	  </xsl:when>
+
+	  <xsl:when test="res:results">
+	    <xsl:call-template name="vb-result" />
+	  </xsl:when>
+
+	</xsl:choose>
+
+
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This PR allows quoted triples to be expressed in SPARQL/XML according to how it was defined in the CG report: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-star-query-results-xml-format

This also adds the various example files to the repo, and updates the request and result files.
Note that the XML Query and XSLT files have **not** been updated yet. I've created an issue for this: #20


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/19.html" title="Last updated on Apr 21, 2023, 9:29 AM UTC (75a7bf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/19/9054dca...75a7bf5.html" title="Last updated on Apr 21, 2023, 9:29 AM UTC (75a7bf5)">Diff</a>