### PR TITLE
Change links to example files "./"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -611,29 +611,29 @@ span.cancast:hover { background-color: #ffa;
 
       <section id="vb-examples">
   <h3>Variable Binding Results Examples</h3>
-  <p>An example <code>SELECT</code> SPARQL Query in <a href="http://www.w3.org/2009/sparql/xml-results/example.rq">example.rq</a> operating on query graph Turtle/N3 data in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/data.n3">data.n3</a> providing ordered variable binding query results written in XML in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/output.srx">output.srx</a>.</p>
-  <p>This XML can be transformed into XHTML using the sample XML Query script <a href="http://www.w3.org/2009/sparql/xml-results/result-to-html.xq">result-to-html.xq</a> giving <a href=
-  "http://www.w3.org/2009/sparql/xml-results/output-xquery.html">output-xquery.html</a> or with XSLT sheet <a href=
-  "http://www.w3.org/2009/sparql/xml-results/result-to-html.xsl">result-to-html.xsl</a> giving <a href="http://www.w3.org/2009/sparql/xml-results/output-xslt.html">output-xslt.html</a></p>
+  <p>An example <code>SELECT</code> SPARQL Query in <a href="./example.rq">example.rq</a> operating on query graph Turtle/N3 data in <a href=
+  "./data.n3">data.n3</a> providing ordered variable binding query results written in XML in <a href=
+  "./output.srx">output.srx</a>.</p>
+  <p>This XML can be transformed into XHTML using the sample XML Query script <a href="./result-to-html.xq">result-to-html.xq</a> giving <a href=
+  "./output-xquery.html">output-xquery.html</a> or with XSLT sheet <a href=
+  "./result-to-html.xsl">result-to-html.xsl</a> giving <a href="./output-xslt.html">output-xslt.html</a></p>
       </section>
 
       <section id="vb-quoted-examples">
   <h3>Variable Binding Results Examples with Quoted Triples</h3>
-  <p>An example <code>SELECT</code> SPARQL Query in <a href="http://www.w3.org/2009/sparql/xml-results/example-quoted.rq">example-quoted.rq</a> operating on query graph Turtle/N3 data in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/data.n3">data.n3</a> providing ordered variable binding query results written in XML in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/output-quoted.srx">output-quoted.srx</a>. These results contain quoted triples.</p>
+  <p>An example <code>SELECT</code> SPARQL Query in <a href="./example-quoted.rq">example-quoted.rq</a> operating on query graph Turtle/N3 data in <a href=
+  "./data.n3">data.n3</a> providing ordered variable binding query results written in XML in <a href=
+  "./output-quoted.srx">output-quoted.srx</a>. These results contain quoted triples.</p>
       </section>
 
       <section id="boolean-examples">
   <h3>Boolean Results Examples</h3>
-  <p>An example <code>ASK</code> SPARQL Query in <a href="http://www.w3.org/2009/sparql/xml-results/example2.rq">example2.rq</a> operating on query graph Turtle/N3 data in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/data.n3">data.n3</a> provides a boolean query result written in XML in <a href=
-  "http://www.w3.org/2009/sparql/xml-results/output2.srx">output2.srx</a>.</p>
-  <p>This XML can be transformed into XHTML using the sample XML Query script <a href="http://www.w3.org/2009/sparql/xml-results/result-to-html.xq">result-to-html.xq</a> giving <a href=
-  "http://www.w3.org/2009/sparql/xml-results/output-xquery2.html">output-xquery2.html</a> or with XSLT sheet <a href=
-  "http://www.w3.org/2009/sparql/xml-results/result-to-html.xsl">result-to-html.xsl</a> giving <a href="http://www.w3.org/2009/sparql/xml-results/output-xslt2.html">output-xslt2.html</a></p>
+  <p>An example <code>ASK</code> SPARQL Query in <a href="./example2.rq">example2.rq</a> operating on query graph Turtle/N3 data in <a href=
+  "./data.n3">data.n3</a> provides a boolean query result written in XML in <a href=
+  "./output2.srx">output2.srx</a>.</p>
+  <p>This XML can be transformed into XHTML using the sample XML Query script <a href="./result-to-html.xq">result-to-html.xq</a> giving <a href=
+  "./output-xquery2.html">output-xquery2.html</a> or with XSLT sheet <a href=
+  "./result-to-html.xsl">result-to-html.xsl</a> giving <a href="./output-xslt2.html">output-xslt2.html</a></p>
       </section>
     </section>
 


### PR DESCRIPTION
This PR makes the links to examples file go to "./FileName".

They were pointing at `http://www.w3.org/2009/sparql/xml-results/FileName`.

I'm not sure where the final destinations will be or whether they will be in the same folder as the spec file. This PR should at least make https://w3c.github.io/sparql-results-xml/spec/index.html work (it does now work as a local file).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/21.html" title="Last updated on Apr 29, 2023, 10:19 AM UTC (d792cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/21/f2fabb4...d792cce.html" title="Last updated on Apr 29, 2023, 10:19 AM UTC (d792cce)">Diff</a>