### PR TITLE
Provide old fragment name

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -663,7 +663,7 @@ span.cancast:hover { background-color: #ffa;
       The document title changed from "SPARQL Query Results XML Format (Second Edition)" to "SPARQL 1.2 Query Results XML Format".
     </section>
 
-    <section id="mediatype">
+    <section id="mediatype"><div id="mime"></div>
   <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
   <p>The Internet Media Type (formerly known as MIME Type) for the SPARQL Query Results XML Format is "application/sparql-results+xml".</p>
   <p>It is recommended that result files have the extension ".srx" (all lowercase) on all platforms.</p>


### PR DESCRIPTION
This applies the comment https://github.com/w3c/sparql-results-xml/pull/37#discussion_r1258650926 .

The document alignment in the window is slightly different (it does not show the section name) but it is in the right area.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/38.html" title="Last updated on Jul 27, 2023, 4:55 PM UTC (c02cc67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/38/16023c4...c02cc67.html" title="Last updated on Jul 27, 2023, 4:55 PM UTC (c02cc67)">Diff</a>