### PR TITLE
Support directional language-tagged strings, Closes #39

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -388,11 +388,19 @@ span.cancast:hover { background-color: #ffa;
   <h3>Document Element</h3>
   <p>The <a href="#defn-srd">SPARQL Results Document</a> begins with <code>sparql</code> document element in the <code>http://www.w3.org/2005/sparql-results#</code> namespace, written as follows:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
  ...
 &lt;/sparql&gt;
 </pre>
   <p>Inside the <code>sparql</code> element are two sub-elements, <code>head</code> and a results element (either <code>results</code> or <code>boolean</code>) which must appear in that order.</p>
+  <p>If no literals with base direction appear in the results, the <code>sparql</code> document element may be simplified as follows.</p>
+  <pre>&lt;?xml version="1.0"?&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+ ...
+&lt;/sparql&gt;
+</pre>
       </section>
 
       <section id="head">
@@ -407,7 +415,9 @@ span.cancast:hover { background-color: #ffa;
     <p>Inside the <code>head</code> element, the ordered sequence of variable names chosen are used to create empty child elements <code>variable</code> with the variable name as the value of an
       attribute <code>name</code> giving a document like this:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
 
   &lt;head&gt;
     &lt;variable name="x"/&gt;
@@ -426,7 +436,9 @@ span.cancast:hover { background-color: #ffa;
   metadata about the query results. The relative URI is resolved against the in-scope base URI which is usually the query results format document URI. <code>link</code> elements must appear after any
   <code>variable</code> elements that are present.</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
 
   &lt;head&gt;
     ...
@@ -448,7 +460,9 @@ span.cancast:hover { background-color: #ffa;
   <p>For each <a data-cite="SPARQL12-QUERY#defn_sparqlSolutionMapping">Query Solution</a> in the query results, a <code>result</code> child-element of
   <code>results</code> is added giving a document like:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
   ...  head ...
 
   &lt;results&gt;
@@ -466,7 +480,9 @@ span.cancast:hover { background-color: #ffa;
   <p>Each binding inside a solution is written as an element <code>binding</code> as a child of <code>result</code> with the query variable name as the value of the <code>name</code> attribute. So
   for a result binding two variables <em>x</em> and <em>hpage</em> it would look like:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
   &lt;head&gt;
     &lt;variable name="x"/&gt;
     &lt;variable name="hpage"/&gt;
@@ -493,8 +509,10 @@ span.cancast:hover { background-color: #ffa;
     <dd><code>&lt;binding&gt;&lt;uri&gt;</code><em>U</em><code>&lt;/uri&gt;&lt;/binding&gt;</code></dd>
     <dt>RDF Literal <em>S</em><br></dt>
     <dd><code>&lt;binding&gt;&lt;literal&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
-    <dt>RDF Literal <em>S</em> with language <em>L</em><br></dt>
+    <dt>RDF Literal <em>S</em> with language <em>L</em> without base direction<br></dt>
     <dd><code>&lt;binding&gt;&lt;literal xml:lang="</code><em>L</em><code>"&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
+    <dt>RDF Literal <em>S</em> with language <em>L</em> with base direction <em>L</em><br></dt>
+    <dd><code>&lt;binding&gt;&lt;literal xml:lang="</code><em>L</em><code>" its:base="</code><em>B</em><code>"&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
     <dt>RDF Typed Literal <em>S</em> with datatype URI <em>D</em><br></dt>
     <dd><code>&lt;binding&gt;&lt;literal datatype="</code><em>D</em><code>"&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
     <dt>Blank Node label <em>I</em><br></dt>
@@ -514,7 +532,9 @@ span.cancast:hover { background-color: #ffa;
   graph.</p>
   <p>An example of a query solution encoded in this format is as follows:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
 
   &lt;head&gt;
     &lt;variable name="x"/&gt;
@@ -551,7 +571,9 @@ span.cancast:hover { background-color: #ffa;
 </pre>
   <p>An example of a query solution that includes quoted triples is as follows:</p>
   <pre>&lt;?xml version="1.0"?&gt;
-&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  xmlns:its="http://www.w3.org/2005/11/its" 
+  its:version="1.0"&gt;
 
   &lt;head&gt;
     &lt;variable name="x"/&gt;

--- a/spec/output-quoted.srx
+++ b/spec/output-quoted.srx
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd"
+        xmlns:its="http://www.w3.org/2005/11/its" 
+        its:version="1.0">
 
   <head>
     <variable name="x"/>

--- a/spec/output.srx
+++ b/spec/output.srx
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd">
+        xsi:schemaLocation="http://www.w3.org/2001/sw/DataAccess/rf1/result2.xsd"
+        xmlns:its="http://www.w3.org/2005/11/its" 
+        its:version="1.0">
 
   <head>
     <variable name="x"/>


### PR DESCRIPTION
Similar to https://github.com/w3c/sparql-results-json/pull/33, `"its:dir"` was chosen as key to be aligned with `"xml:lang"` following https://www.w3.org/TR/2007/REC-its-20070403/#att.dir

This requires the `"its"` namespace to be added to results that include literals with base directions.