### PR TITLE
Migrate from quoted triples to triple terms

### DIFF
--- a/spec/data.ttl
+++ b/spec/data.ttl
@@ -8,11 +8,11 @@ _:a  foaf:homepage   <http://work.example.org/alice/> .
 _:a  foaf:mbox       "" .
 _:a  ex:blurb       "<p xmlns=\"http://www.w3.org/1999/xhtml\">My name is <em>Alice</em></p>"^^rdf:XMLLiteral .
 _:a  foaf:knows      _:b .
-_:a  ex:quoted       << <http://example.org/alice> <http://example.org/name> "Alice" >> .
+_:a  ex:triple       <<( <http://example.org/alice> <http://example.org/name> "Alice" )>> .
 
 _:b  foaf:name       "Bob"@en .
 _:b  foaf:mbox       <mailto:bob@work.example.org> .
 _:b  foaf:homepage   <http://work.example.org/bob/> .
 _:b  ex:ageInYears   30 .
 _:b  foaf:knows      _:a .
-_:b  ex:quoted       << <http://example.org/bob> <http://example.org/name> "Bob" >> .
+_:b  ex:triple       <<( <http://example.org/bob> <http://example.org/name> "Bob" )>> .

--- a/spec/example-triple-terms.rq
+++ b/spec/example-triple-terms.rq
@@ -1,9 +1,9 @@
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ex: <http://ns.example.org/#>
 
-SELECT ?x ?name ?quoted
+SELECT ?x ?name ?triple
 FROM <data.n3>
 WHERE { ?x foaf:name ?name .
-        ?x ex:quoted ?quoted .
+        ?x ex:triple ?triple .
       }
 ORDER BY ?name

--- a/spec/index.html
+++ b/spec/index.html
@@ -518,7 +518,7 @@ span.cancast:hover { background-color: #ffa;
     <dd><code>&lt;binding&gt;&lt;literal datatype="</code><em>D</em><code>"&gt;</code><em>S</em><code>&lt;/literal&gt;&lt;/binding&gt;</code></dd>
     <dt>Blank Node label <em>I</em><br></dt>
     <dd><code>&lt;binding&gt;&lt;bnode&gt;</code><em>I</em><code>&lt;/bnode&gt;&lt;/binding&gt;</code></dd>
-    <dt>Quoted Triple, with subject <em>S</em>, predicate <em>P</em>, object <em>O</em><br></dt>
+    <dt>Triple Term, with subject <em>S</em>, predicate <em>P</em>, object <em>O</em><br></dt>
     <dd><code>&lt;binding&gt;<br />
 &nbsp;&nbsp;&lt;triple&gt;<br />
 &nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt;</code><em>S</em><code>&lt;/subject&gt;<br />
@@ -528,7 +528,7 @@ span.cancast:hover { background-color: #ffa;
 &lt;/binding&gt;</code></dd>
   </dl>
   <p>If, for a particular solution, a variable is <em>unbound</em>, no <code>binding</code> element for that variable is included in the <code>result</code> element.</p>
-  <p><em>S</em>, <em>P</em>, and <em>O</em> in Quoted Triples are encoded recursively, using the same format, without the enclosing <code>&lt;binding&gt;</code> tag</p>
+  <p><em>S</em>, <em>P</em>, and <em>O</em> in Triple Terms are encoded recursively, using the same format, without the enclosing <code>&lt;binding&gt;</code> tag</p>
   <p><strong>Note:</strong> The blank node label <em>I</em> is scoped to the result set XML document and need not have any association to the blank node label for that RDF Term in the query
   graph.</p>
   <p>An example of a query solution encoded in this format is as follows:</p>
@@ -570,7 +570,7 @@ span.cancast:hover { background-color: #ffa;
 
 &lt;/sparql&gt;
 </pre>
-  <p>An example of a query solution that includes quoted triples is as follows:</p>
+  <p>An example of a query solution that includes triple terms is as follows:</p>
   <pre>&lt;?xml version="1.0"?&gt;
 &lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
   xmlns:its="http://www.w3.org/2005/11/its" 
@@ -579,7 +579,7 @@ span.cancast:hover { background-color: #ffa;
   &lt;head&gt;
     &lt;variable name="x"/&gt;
     &lt;variable name="name"/&gt;
-    &lt;variable name="quoted"/&gt;
+    &lt;variable name="triple"/&gt;
   &lt;/head&gt;
 
   &lt;results&gt;
@@ -591,7 +591,7 @@ span.cancast:hover { background-color: #ffa;
       &lt;binding name="name"&gt;
         &lt;literal xml:lang="en"&gt;Bob&lt;/literal&gt;
       &lt;/binding&gt;
-      &lt;binding name="quoted"&gt;
+      &lt;binding name="triple"&gt;
         &lt;triple&gt;
             &lt;subject&gt;
                 &lt;uri&gt;http://example.org/alice&lt;/uri&gt;
@@ -642,11 +642,11 @@ span.cancast:hover { background-color: #ffa;
   "./result-to-html.xsl">result-to-html.xsl</a> giving <a href="./output-xslt.html">output-xslt.html</a></p>
       </section>
 
-      <section id="vb-quoted-examples">
-  <h3>Variable Binding Results Examples with Quoted Triples</h3>
-  <p>An example <code>SELECT</code> SPARQL Query in <a href="./example-quoted.rq">example-quoted.rq</a> operating on query graph Turtle/N3 data in <a href=
+      <section id="vb-triple-terms-examples">
+  <h3>Variable Binding Results Examples with Triple Terms</h3>
+  <p>An example <code>SELECT</code> SPARQL Query in <a href="./example-triple-terms.rq">example-triple-terms.rq</a> operating on query graph Turtle/N3 data in <a href=
   "./data.ttl">data.ttl</a> providing ordered variable binding query results written in XML in <a href=
-  "./output-quoted.srx">output-quoted.srx</a>. These results contain quoted triples.</p>
+  "./output-triple-terms.srx">output-triple-terms.srx</a>. These results contain triple terms.</p>
       </section>
 
       <section id="boolean-examples">
@@ -686,7 +686,7 @@ span.cancast:hover { background-color: #ffa;
       <ul>
         <li>The document title changed from "SPARQL Query Results XML Format (Second Edition)" to "SPARQL 1.2 Query Results XML Format"</li>
         <li>Add RNC, RNG, and XSD files</li>
-        <li>Allow quoted triples to be expressed in <a href="#vb-results" class="sectionRef"></a></li>
+        <li>Allow triple terms to be expressed in <a href="#vb-results" class="sectionRef"></a></li>
         <li>Use Media Type language instead of MIME Type in <a href="#mediatype" class="sectionRef"></a></li>
         <li>Support directional language-tagged strings in <a href="#vb-results" class="sectionRef"></a></li>
       </ul>

--- a/spec/output-triple-terms.srx
+++ b/spec/output-triple-terms.srx
@@ -8,9 +8,9 @@
   <head>
     <variable name="x"/>
     <variable name="name"/>
-    <variable name="quoted"/>
+    <variable name="triple"/>
 
-    <link href="example-quoted.rq" />
+    <link href="example-triple.rq" />
   </head>
 
   <results>
@@ -18,7 +18,7 @@
     <result>
       <binding name="x"><bnode>r1</bnode></binding>
       <binding name="name"><literal>Alice</literal></binding>
-      <binding name="quoted">
+      <binding name="triple">
         <triple>
           <subject>
               <uri>http://example.org/alice</uri>
@@ -36,7 +36,7 @@
     <result> 
       <binding name="x"><bnode>r2</bnode></binding>
       <binding name="name"><literal xml:lang="en">Bob</literal></binding>
-      <binding name="quoted">
+      <binding name="triple">
         <triple>
           <subject>
               <uri>http://example.org/bob</uri>


### PR DESCRIPTION
Following the changes in https://github.com/w3c/rdf-concepts/commit/6b7ea76dccfa4ec0d5c9b94cdce7d22dcc0536e5, this PR uses triple terms instead of quoted triples.

Related to https://github.com/w3c/sparql-query/pull/149


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/44.html" title="Last updated on Aug 12, 2024, 7:14 AM UTC (fdcc7c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/44/887d173...fdcc7c5.html" title="Last updated on Aug 12, 2024, 7:14 AM UTC (fdcc7c5)">Diff</a>