### PR TITLE
Example of base direction namespace inline

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -605,6 +605,38 @@ span.cancast:hover { background-color: #ffa;
 
 &lt;/sparql&gt;
 </pre>
+
+  <p>
+    As an alternative to including the `xml:its` declaration in every result
+    set, the namespace can be declared on specific elements as needed:
+  </p>
+
+  <pre class="box xml">&lt;?xml version="1.0"?&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"&gt;
+  &lt;head&gt;
+    &lt;variable name="animal"/&gt;
+  &lt;/head&gt;
+  &lt;results&gt;
+    &lt;result&gt;
+      &lt;binding name="animal"&gt;
+        &lt;literal xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0"
+                 xml:lang="ar" its:dir="rtl"&gt;قطة&lt;/literal&gt;
+      &lt;/binding&gt;
+    &lt;/result&gt;
+    &lt;result&gt;
+      &lt;binding name="animal"&gt;
+        &lt;literal xml:lang="en"&gt;cat&lt;/literal&gt;
+      &lt;/binding&gt;
+    &lt;/result&gt;
+    &lt;result&gt;
+      &lt;binding name="animal"&gt;
+        &lt;literal xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0"
+                 xml:lang="fr" its:dir="ltr"&gt;chat&lt;/literal&gt;
+      &lt;/binding&gt;
+    &lt;/result&gt;
+  &lt;/results&gt;
+&lt;/sparql&gt;
+</pre>
         </section>
 
         <section id="boolean-results">


### PR DESCRIPTION
This closes #51.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/54.html" title="Last updated on Dec 20, 2024, 10:20 AM UTC (f530610)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/54/3ca89f9...f530610.html" title="Last updated on Dec 20, 2024, 10:20 AM UTC (f530610)">Diff</a>