### PR TITLE
Add version announcement support

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -378,7 +378,7 @@ span.cancast:hover { background-color: #ffa;
         The `version` <a href="#mediatype">Media Type parameter</a> MAY be set to `1.2`
         to indicate possible use of RDF 1.2 features in the SPARQL results.
         Alternatively, the <a href="#docElement">`"version"` child element</a> MAY be used to specify this version.</p>
-        <p>Possible values for the version string are discussed in <a data-cite="RDF12-CONCEPTS#section-version-announcement"></a>.</p>
+        <p>Possible values for the version string are discussed in <a data-cite="RDF12-CONCEPTS#defined-version-labels"></a>.</p>
         <p>When providing content over HTTP, servers can announce the version
         using the optional `version` <a href="#mediatype">Media Type parameter</a>:</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -368,6 +368,39 @@ span.cancast:hover { background-color: #ffa;
     [[[SPARQL12-RESULTS-JSON]]] and 
     [[[SPARQL12-RESULTS-CSV-TSV]]].
   </p>
+
+      <section id="version-announcement">
+        <h3>Version Announcement</h3>
+        <p>
+        An optional version can be given to SPARQL results.
+        </p>
+        <p>
+        The `version` <a href="#mediatype">Media Type parameter</a> MAY be set to `1.2`
+        to indicate possible use of RDF 1.2 features in the SPARQL results.
+        Alternatively, the <a href="#docElement">`"version"` child element</a> MAY be used to specify this version.</p>
+        <p>Possible values for the version string are discussed in <a data-cite="RDF12-CONCEPTS#section-version-announcement"></a>.</p>
+        <p>When providing content over HTTP, servers can announce the version
+        using the optional `version` <a href="#mediatype">Media Type parameter</a>:</p>
+
+        <pre id="ex-http-version-decl"
+             class="box http"
+             title="HTTP version announcement">GET /sparql/?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20%0ASELECT%20%3Fbook%20%3Fwho%20%0AWHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D%0A HTTP/1.1
+    Host: www.example
+    Accept: application/sparql-results+xml; version=1.2
+        </pre>
+
+        <p class="note">When using RDF 1.2-specific features, such as
+        <a data-cite="RDF12-CONCEPTS#dfn-base-direction">initial text direction</a>,
+        the specific RDF version can be announced using
+        either the `version` <a href="#mediatype">Media Type parameter</a>
+        or the <a href="#docElement">`version` child element</a> early in the document.
+        This allows parsers that do not support these features to detect
+        the presense of such features early, and potentially
+        inform the user, giving them an opportunity to stop the job
+        or otherwise act on the fact that some amount of the input data
+        will not be processed as desired.
+        </p>
+      </section>
     </section>
       
     <section id="definition">
@@ -396,6 +429,13 @@ span.cancast:hover { background-color: #ffa;
 &lt;/sparql&gt;
 </pre>
   <p class="note">Different values of <code>its:version</code> are allowed.</p>
+  <p>The optional <code>version</code> attribute MAY be used on the <code>sparql</code> element to announce that RDF 1.2 functionalities are used in the results as follows.</p>
+  <pre class="box xml">&lt;?xml version="1.0"?&gt;
+&lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
+  version="1.2"&gt;
+ ...
+&lt;/sparql&gt;
+</pre>
       </section>
 
       <section id="head">
@@ -715,6 +755,7 @@ span.cancast:hover { background-color: #ffa;
         <li>Allow triple terms to be expressed in <a href="#vb-results" class="sectionRef"></a></li>
         <li>Use Media Type language instead of MIME Type in <a href="#mediatype" class="sectionRef"></a></li>
         <li>Support directional language-tagged strings in <a href="#vb-results" class="sectionRef"></a></li>
+        <li>Add version announcement in <a href="#version-announcement" class="sectionRef"></a> and <a href="#docElement" class="sectionRef"></a></li>
       </ul>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -430,7 +430,7 @@ span.cancast:hover { background-color: #ffa;
 </pre>
   <p class="note">Different values of <code>its:version</code> are allowed.</p>
   <p>The optional <code>version</code> attribute MAY be used on the <code>sparql</code> element to announce that RDF 1.2 functionalities are used in the results as follows.</p>
-  <pre class="box xml">&lt;?xml version="1.0"?&gt;
+  <pre class="box xml">...
 &lt;sparql xmlns="http://www.w3.org/2005/sparql-results#"
   version="1.2"&gt;
  ...


### PR DESCRIPTION
Very similar to https://github.com/w3c/sparql-results-json/pull/48, this adds version announcement support for SPARQL/XML results.

In https://github.com/w3c/rdf-star-wg/issues/141 there were some different opinions on where the version should be defined. Either on the `sparql` element as attribute, or in the `head` element.
For consistency with `its:version`, I went for the first approach, but I'm definitely open to the other approach if there are strong opinions for that one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/pull/56.html" title="Last updated on May 9, 2025, 9:35 AM UTC (b3bdf38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-xml/56/8cfa0c5...b3bdf38.html" title="Last updated on May 9, 2025, 9:35 AM UTC (b3bdf38)">Diff</a>